### PR TITLE
Einstellen des Limits für das Leuchten

### DIFF
--- a/widgets/trashschedule.html
+++ b/widgets/trashschedule.html
@@ -12,7 +12,7 @@
         type="text/ejs"
         class="vis-tpl"
         data-vis-prev='<div id="prev_tplTrashscheduleHelper" style="position: relative; text-align: initial;padding: 4px "><div class="vis-widget_prev trashschedule-widget" style="width: 105px; height: 275px;"><div class="trashtypes"><div class="trashtype"><span class="name">Restabfall</span><div class="dumpster"><span class="daysleft">3</span></div><span class="nextdate">Di., 10.3.</span></div></div></div>'
-        data-vis-attrs="oid[trashschedule.0.type.json]/id;size[100]/slider,0,100,1;limit[0]/slider,0,10,1;glow/checkbox;showName[true]/checkbox;showDate[true]/checkbox;dateLocale[de-DE]/select,de-DE,en-US;dateWeekday[long]/select,hide,long,short"
+        data-vis-attrs="oid[trashschedule.0.type.json]/id;size[100]/slider,0,100,1;limit[0]/slider,0,10,1;glow/checkbox;;limitGlow[1];showName[true]/checkbox;showDate[true]/checkbox;dateLocale[de-DE]/select,de-DE,en-US;dateWeekday[long]/select,hide,long,short"
         data-vis-set="trashschedule"
         data-vis-name="TrashSchedule">
     <div class="vis-widget trashschedule-widget <%== this.data.attr('class') %>" style="overflow: visible; width: 575px; height: 275px;" id="<%= this.data.attr('wid') %>">

--- a/widgets/trashschedule.html
+++ b/widgets/trashschedule.html
@@ -12,7 +12,7 @@
         type="text/ejs"
         class="vis-tpl"
         data-vis-prev='<div id="prev_tplTrashscheduleHelper" style="position: relative; text-align: initial;padding: 4px "><div class="vis-widget_prev trashschedule-widget" style="width: 105px; height: 275px;"><div class="trashtypes"><div class="trashtype"><span class="name">Restabfall</span><div class="dumpster"><span class="daysleft">3</span></div><span class="nextdate">Di., 10.3.</span></div></div></div>'
-        data-vis-attrs="oid[trashschedule.0.type.json]/id;size[100]/slider,0,100,1;limit[0]/slider,0,10,1;glow/checkbox;limitGlow[1]/slider,0,10,1;showName[true]/checkbox;showDate[true]/checkbox;dateLocale[de-DE]/select,de-DE,en-US;dateWeekday[long]/select,hide,long,short"
+        data-vis-attrs="oid[trashschedule.0.type.json]/id;size[100]/slider,0,100,1;limit[0]/slider,0,10,1;glow/checkbox;glowLimit[1]/slider,0,10,1;showName[true]/checkbox;showDate[true]/checkbox;dateLocale[de-DE]/select,de-DE,en-US;dateWeekday[long]/select,hide,long,short"
         data-vis-set="trashschedule"
         data-vis-name="TrashSchedule">
     <div class="vis-widget trashschedule-widget <%== this.data.attr('class') %>" style="overflow: visible; width: 575px; height: 275px;" id="<%= this.data.attr('wid') %>">

--- a/widgets/trashschedule.html
+++ b/widgets/trashschedule.html
@@ -12,7 +12,7 @@
         type="text/ejs"
         class="vis-tpl"
         data-vis-prev='<div id="prev_tplTrashscheduleHelper" style="position: relative; text-align: initial;padding: 4px "><div class="vis-widget_prev trashschedule-widget" style="width: 105px; height: 275px;"><div class="trashtypes"><div class="trashtype"><span class="name">Restabfall</span><div class="dumpster"><span class="daysleft">3</span></div><span class="nextdate">Di., 10.3.</span></div></div></div>'
-        data-vis-attrs="oid[trashschedule.0.type.json]/id;size[100]/slider,0,100,1;limit[0]/slider,0,10,1;glow/checkbox;;limitGlow[1];showName[true]/checkbox;showDate[true]/checkbox;dateLocale[de-DE]/select,de-DE,en-US;dateWeekday[long]/select,hide,long,short"
+        data-vis-attrs="oid[trashschedule.0.type.json]/id;size[100]/slider,0,100,1;limit[0]/slider,0,10,1;glow/checkbox;limitGlow[1]/slider,0,10,1;showName[true]/checkbox;showDate[true]/checkbox;dateLocale[de-DE]/select,de-DE,en-US;dateWeekday[long]/select,hide,long,short"
         data-vis-set="trashschedule"
         data-vis-name="TrashSchedule">
     <div class="vis-widget trashschedule-widget <%== this.data.attr('class') %>" style="overflow: visible; width: 575px; height: 275px;" id="<%= this.data.attr('wid') %>">

--- a/widgets/trashschedule/js/trashschedule.js
+++ b/widgets/trashschedule/js/trashschedule.js
@@ -49,6 +49,19 @@ $.extend(
             "uk": "Пожовтий, коли",
             "zh-cn": "到期时发光"
         },
+        "glowLimit": {
+            "en": "days for glowing",
+            "de": "Tage für leuchten",
+            "ru": "Свечение, когда из-за",
+            "pt": "Brilhar quando devido",
+            "nl": "Gloed wanneer het moet",
+            "fr": "Briller à l'échéance",
+            "it": "Bagliore quando dovuto",
+            "es": "Resplandece cuando es debido",
+            "pl": "Świeci się, gdy należy",
+            "uk": "Пожовтий, коли",
+            "zh-cn": "到期时发光"
+        },
         "showName": {
             "en": "Show name",
             "de": "Name anzeigen",
@@ -177,6 +190,7 @@ vis.binds['trashschedule'] = {
         const size = data.size ? parseInt(data.size) : 100;
         const limit = data.limit ? parseInt(data.limit) : 0; // 0 = no limit
         const glow = !!data.glow;
+        const glowLimit = data.glowLimit ? parseInt(data.glowLimit) : 1; // 1 defaults to (daysLeft <= 1)
         const showName = Object.prototype.hasOwnProperty.call(data, 'showName') ? !!data.showName : true;
         const showDate = !!data.showDate;
         const dateLocale = data.dateLocale ? data.dateLocale : 'de-DE';
@@ -365,7 +379,7 @@ vis.binds['trashschedule'] = {
                             newItem.addClass('trash-today');
                         }
 
-                        if (glow && trashType.daysLeft <= 1) {
+                        if (glow && trashType.daysLeft <= glowLimit) {
                             newItem.addClass('trash-glow');
                         }
 

--- a/widgets/trashschedule/js/trashschedule.js
+++ b/widgets/trashschedule/js/trashschedule.js
@@ -203,12 +203,12 @@ vis.binds['trashschedule'] = {
         }
 
         // update based on current value
-        vis.binds['trashschedule'].redraw($div.find('.trashtypes'), vis.states[oid + '.val'], size, limit, glow, showName, showDate, dateLocale, dateOptions);
+        vis.binds['trashschedule'].redraw($div.find('.trashtypes'), vis.states[oid + '.val'], size, limit, glow, glowLimit, showName, showDate, dateLocale, dateOptions);
 
         // subscribe on updates of value
         if (oid) {
             vis.states.bind(oid + '.val', function (e, newVal, oldVal) {
-                vis.binds['trashschedule'].redraw($div.find('.trashtypes'), newVal, size, limit, glow, showName, showDate, dateLocale, dateOptions);
+                vis.binds['trashschedule'].redraw($div.find('.trashtypes'), newVal, size, limit, glow, glowLimit, showName, showDate, dateLocale, dateOptions);
             });
         }
     },
@@ -355,7 +355,7 @@ vis.binds['trashschedule'] = {
             return x;
         });
     },
-    redraw: function (target, json, size, limit, glow, showName, showDate, dateLocale, dateOptions) {
+    redraw: function (target, json, size, limit, glow, glowLimit, showName, showDate, dateLocale, dateOptions) {
 
         if (json) {
             target.empty();

--- a/widgets/trashschedule/js/trashschedule.js
+++ b/widgets/trashschedule/js/trashschedule.js
@@ -50,17 +50,8 @@ $.extend(
             "zh-cn": "到期时发光"
         },
         "glowLimit": {
-            "en": "days for glowing",
-            "de": "Tage für leuchten",
-            "ru": "Свечение, когда из-за",
-            "pt": "Brilhar quando devido",
-            "nl": "Gloed wanneer het moet",
-            "fr": "Briller à l'échéance",
-            "it": "Bagliore quando dovuto",
-            "es": "Resplandece cuando es debido",
-            "pl": "Świeci się, gdy należy",
-            "uk": "Пожовтий, коли",
-            "zh-cn": "到期时发光"
+            "en": "Days (Glow)",
+            "de": "Tage (Leuchten)",
         },
         "showName": {
             "en": "Show name",

--- a/widgets/trashschedule/js/trashschedule.js
+++ b/widgets/trashschedule/js/trashschedule.js
@@ -52,6 +52,15 @@ $.extend(
         "glowLimit": {
             "en": "Days (Glow)",
             "de": "Tage (Leuchten)",
+            "ru": "Days (Glow)",
+            "pt": "Days (Glow)",
+            "nl": "Days (Glow)",
+            "fr": "Days (Glow)",
+            "it": "Days (Glow)",
+            "es": "Days (Glow)",
+            "pl": "Days (Glow)",
+            "uk": "Days (Glow)",
+            "zh-cn": "Days (Glow)"
         },
         "showName": {
             "en": "Show name",


### PR DESCRIPTION
Am Widget lässt sich nun einstellen, ab welcher zeitlichen Grenze die Zahl für die verbleibenden Tage beginnt zu blinken.